### PR TITLE
bugfix マナ軽減の腕輪

### DIFF
--- a/eoc/meta.json
+++ b/eoc/meta.json
@@ -119,7 +119,7 @@
       "u_has_trait": "PSY_metamagic_reduction"
     },
     "effect": [
-      { "math": [ "u_spellcasting_adjustment('cost' )", "=", "0.5" ] },
+      { "math": [ "u_spellcasting_adjustment('cost' )", "=", "-0.5" ] },
       { "math": [ "u_spellcasting_adjustment('difficulty' )", "=", "3" ] }
     ]
   }

--- a/items/enchanted_item.json
+++ b/items/enchanted_item.json
@@ -695,9 +695,9 @@
     "id": "PSY_magi_bracelet_magicreduction",
     "type": "ARMOR",
     "name": { "str": "マナ軽減の腕輪[MWMI]" },
-    "description": "見たことがない文字が掘られた銅製の腕輪です。これを身に着けることで魔法のコストを50%軽減させる代わりに魔法の難易度が1上昇します。",
+    "description": "見たことがない文字が掘られた銅製の腕輪です。これを身に着けることで魔法のコストを50%軽減させる代わりに魔法の難易度が3上昇します。",
     "copy-from": "copper_bracelet",
     "price_postapoc": "5000 USD",
-    "relic_data": { "passive_effects": [ { "id": "PSY_magi_ench_metamagic_intuitive" } ] }
+    "relic_data": { "passive_effects": [ { "id": "PSY_magi_ench_metamagic_reduction" } ] }
   }
 ]

--- a/items/gun/other.json
+++ b/items/gun/other.json
@@ -6,7 +6,7 @@
     "reload_noise_volume": 10,
     "name": { "str_sp": "☆ライフル(ミ=ゴの試作雷撃銃)" },
     "description": "ミ=ゴが研究していた大型の回転弾倉式の試作ライフルです。汚染肉や変異肉をチャンバー内に詰め込み、トリガーを引くことで汚染肉からブロブのエネルギーを取り出し電力に変換して発射する銃です。",
-    "copy-from": "ar15",
+    "copy-from": "modular_ar15",
     "weight": "2290 g",
     "volume": "4610 ml",
     "longest_side": "1300 mm",


### PR DESCRIPTION
マナ軽減の腕輪で取得する変異が無心詠唱になっていたのを修正、また、呪文コストが実際には1.5倍になっていたのでその修正と呪文上昇の効果と説明文に食い違いがあったので説明文の方を修正してあります。
また、最新開発版向けになりますがミゴの電撃銃のidも更新されています。